### PR TITLE
Documentación de servidores y guía de entorno

### DIFF
--- a/servidor_basico.py
+++ b/servidor_basico.py
@@ -19,11 +19,18 @@ MODEL_PATH = "entrenamiento/IA_Movimientos.joblib"  # ruta fija a tu modelo
 
 # ==================== FEATURES ====================
 def ingenieriaCaracteristicas(df: pd.DataFrame):
+    """Calcula cinco características estadísticas a partir de una ventana de aceleraciones."""
+    # Calcula la media del eje X para estimar la inclinación o sesgo en esa dirección.
     F1 = df['Ax'].mean()
+    # Calcula la media del eje Y para detectar tendencia de aceleración lateral.
     F2 = df['Ay'].mean()
+    # Calcula la media del eje Z para captar el componente vertical del movimiento.
     F3 = df['Az'].mean()
+    # Promedia las desviaciones estándar de los tres ejes como indicador de variabilidad global.
     F4 = (df['Ax'].std() + df['Ay'].std() + df['Az'].std()) / 3.0
+    # Obtiene la magnitud media del vector de aceleración (norma) como energía del movimiento.
     F5 = np.sqrt(df['Ax']**2 + df['Ay']**2 + df['Az']**2).mean()
+    # Devuelve la lista con las cinco características en el orden esperado por el modelo.
     return [F1, F2, F3, F4, F5]
 
 # ==================== DECODIFICACIÓN ====================
@@ -31,106 +38,164 @@ MESSAGE_LENGTH = 13
 SENSOR_TAG_MAP = {ord('A'): "acc", ord('a'): "acc", 1: "acc"}
 
 def decode_serialsensor_binary(pkt: bytes):
+    """Interpreta un paquete binario de Serial Sensor y extrae aceleraciones XYZ."""
+    # Valida que el paquete tenga exactamente la longitud esperada de 13 bytes.
     if len(pkt) != MESSAGE_LENGTH:
         return None
+    # Obtiene el primer byte, que representa el identificador del sensor.
     tag = pkt[0]
+    # Traduce el identificador a un prefijo textual según el mapa permitido.
     pref = SENSOR_TAG_MAP.get(tag)
+    # Si el prefijo no corresponde a acelerómetro, se descarta el paquete.
     if pref != "acc":
         return None
     try:
+        # Extrae el valor de aceleración X interpretando 4 bytes a partir del offset 1.
         x = struct.unpack_from('<f', pkt, 1)[0]
+        # Extrae el valor Y interpretando otros 4 bytes desde el offset 5.
         y = struct.unpack_from('<f', pkt, 5)[0]
+        # Extrae el valor Z con 4 bytes adicionales a partir del offset 9.
         z = struct.unpack_from('<f', pkt, 9)[0]
+        # Devuelve los tres ejes en formato de tupla normalizada.
         return ("acc", float(x), float(y), float(z))
     except Exception:
+        # Cualquier error de desempaquetado se captura y se devuelve None.
         return None
 
 def iter_pairs_from_json_msg(msg: dict):
+    """Normaliza distintas variantes de mensajes JSON y produce pares (sensor, eje, valor)."""
+    # Recorre una copia de los pares clave/valor para poder modificar sin afectar el original.
     for k, v in list(msg.items()):
+        # Solo procesa claves que contengan separador de sensor:eje.
         if isinstance(k, str) and ":" in k:
+            # Divide la clave en prefijo de sensor y eje individual.
             s, a = k.split(":", 1)
+            # Limpia espacios y normaliza a minúsculas.
             s, a = s.strip().lower(), a.strip().lower()
+            # Comprueba que el prefijo represente un acelerómetro y que el eje sea válido.
             if s in ("accel","accelerometer","acc") and a in ("x","y","z"):
+                # Entrega el eje correspondiente junto con su valor original.
                 yield "acc", a, v
+    # Obtiene el subobjeto "sensordata" si está presente.
     sd = msg.get("sensordata")
+    # Verifica que el subobjeto sea un diccionario para inspeccionarlo.
     if isinstance(sd, dict):
+        # Itera por cada sensor incluido dentro de la clave "sensordata".
         for sensor, payload in sd.items():
+            # Filtra aquellos cuyo nombre indique acelerómetro.
             if str(sensor).lower().startswith("acc"):
+                # Si el payload es una secuencia de tres valores, los asigna a ejes XYZ.
                 if isinstance(payload, (list, tuple)) and len(payload) >= 3:
+                    # Empareja cada eje con el valor correspondiente de la secuencia.
                     for a, val in zip(("x","y","z"), payload[:3]):
                         yield "acc", a, val
 
 # ==================== MAIN ====================
 def main():
-    # Cargar modelo entrenado
+    """Gestiona el ciclo principal: carga el modelo, escucha UDP y emite predicciones."""
+    # Intenta cargar el modelo entrenado desde disco para obtener probabilidades reales.
     try:
         model = joblib.load(MODEL_PATH)
+        # Confirma por consola que el modelo se cargó correctamente.
         print(f"[MODEL] Modelo cargado: {MODEL_PATH}")
     except Exception as e:
+        # Si falla la carga, se recurre a un umbral manual sobre la característica F5.
         model = None
         print(f"[MODEL] No se pudo cargar {MODEL_PATH}: {e}")
+        # Define el umbral empírico que separa movimientos rápidos de lentos.
         f5_threshold = 13.1425
 
-    # Socket UDP
+    # Crea el socket UDP que recibirá las lecturas de aceleración.
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    # Asocia el socket a la interfaz y puerto configurados.
     sock.bind((UDP_HOST, UDP_PORT))
+    # Establece un timeout para evitar bloqueo indefinido en recvfrom.
     sock.settimeout(1.0)
+    # Informa dónde está escuchando el servidor.
     print(f"[UDP] Escuchando en {UDP_HOST}:{UDP_PORT}")
 
+    # Crea la ventana deslizante que acumula muestras recientes.
     window = deque()
+    # Guarda el instante de la última predicción para espaciar las ejecuciones.
     last_pred_t = 0.0
 
     try:
         while True:
+            # Registra el tiempo actual para purgar la ventana y etiquetar muestras.
             now = time.time()
+            # Determina el límite inferior de la ventana según WINDOW_SEC.
             cutoff = now - WINDOW_SEC
+            # Elimina muestras más antiguas que el corte temporal.
             while window and window[0][0] < cutoff:
                 window.popleft()
 
             try:
+                # Intenta recibir un datagrama UDP de hasta 65535 bytes.
                 data, _ = sock.recvfrom(65535)
             except socket.timeout:
+                # Si se agota el tiempo sin datos, continúa el ciclo sin fallar.
                 data = None
 
             if data:
+                # Caso de trama binaria exacta proveniente de Serial Sensor.
                 if len(data) == MESSAGE_LENGTH:
                     decoded = decode_serialsensor_binary(data)
                     if decoded:
+                        # Extrae los tres ejes y los añade a la ventana con el timestamp actual.
                         _, x, y, z = decoded
                         window.append((now, x, y, z))
+                # Caso de mensaje JSON (objeto o lista) identificado por llaves o corchetes.
                 elif data[:1] in (b'{', b'['):
                     try:
+                        # Decodifica el payload a texto UTF-8 y luego a estructura Python.
                         msg = json.loads(data.decode("utf-8", errors="ignore"))
                     except:
+                        # Si falla la decodificación, se descarta el paquete.
                         msg = None
                     if isinstance(msg, dict):
+                        # Inicializa un contenedor para asegurar que existan los tres ejes.
                         axes = {"x": None, "y": None, "z": None}
+                        # Itera sobre las variantes admitidas y rellena los ejes encontrados.
                         for pref, axis, val in iter_pairs_from_json_msg(msg):
                             if pref == "acc":
                                 axes[axis] = float(val)
+                        # Solo agrega a la ventana si están presentes los tres ejes.
                         if None not in axes.values():
                             window.append((now, axes["x"], axes["y"], axes["z"]))
 
+            # Comprueba si ya pasó el intervalo mínimo y hay datos suficientes para predecir.
             if (now - last_pred_t) >= STEP_SEC and len(window) > 3:
+                # Actualiza el instante de la última inferencia realizada.
                 last_pred_t = now
+                # Convierte la ventana a un array NumPy para manipularla eficientemente.
                 arr = np.array([[t, ax, ay, az] for (t, ax, ay, az) in window])
+                # Crea un DataFrame solo con columnas de aceleración para las features.
                 df_win = pd.DataFrame(arr[:,1:], columns=["Ax","Ay","Az"])
+                # Calcula las cinco características necesarias para el clasificador.
                 F = ingenieriaCaracteristicas(df_win)
 
                 if model:
+                    # Obtiene la probabilidad de movimiento rápido (clase positiva).
                     prob = model.predict_proba([F])[0,1]
+                    # Asigna la etiqueta según el umbral 0.5 típico de modelos binarios.
                     pred = "R" if prob >= 0.5 else "L"
                 else:
+                    # En modo sin modelo, compara la energía (F5) con el umbral definido.
                     pred = "R" if F[4] > f5_threshold else "L"
+                    # Aproxima una probabilidad suave aplicando una sigmoide alrededor del umbral.
                     prob = 1 / (1 + np.exp(-(F[4]-f5_threshold)))
 
+                # Genera una marca de tiempo legible para la consola.
                 ts = datetime.now().strftime("%H:%M:%S")
+                # Imprime la predicción, probabilidad y valores de las características.
                 print(f"[{ts}] Pred={pred} Prob_Rapido={prob:.3f} "
                       f"F1={F[0]:.2f} F2={F[1]:.2f} F3={F[2]:.2f} F4={F[3]:.2f} F5={F[4]:.2f} n={len(window)}")
 
     except KeyboardInterrupt:
+        # Permite terminar el programa con Ctrl+C mostrando un mensaje amistoso.
         print("\n[EXIT] Interrumpido por usuario.")
     finally:
+        # Garantiza que el socket se cierre aunque ocurra una excepción.
         sock.close()
 
 if __name__ == "__main__":

--- a/servidor_web.py
+++ b/servidor_web.py
@@ -28,11 +28,18 @@ POLL_MS   = 500           # refresco del frontend
 
 # ==================== FEATURES ====================
 def ingenieriaCaracteristicas(df: pd.DataFrame):
+    """Genera cinco descriptores numéricos a partir de una ventana de aceleraciones."""
+    # Calcula la media del eje X como medida del componente longitudinal.
     F1 = df['Ax'].mean()
+    # Calcula la media del eje Y para identificar tendencias laterales.
     F2 = df['Ay'].mean()
+    # Calcula la media del eje Z para capturar el efecto vertical.
     F3 = df['Az'].mean()
+    # Calcula la media de las desviaciones estándar para sintetizar la variabilidad total.
     F4 = (df['Ax'].std() + df['Ay'].std() + df['Az'].std()) / 3.0
+    # Calcula la magnitud promedio del vector de aceleración como energía del movimiento.
     F5 = np.sqrt(df['Ax']**2 + df['Ay']**2 + df['Az']**2).mean()
+    # Devuelve las características convertidas explícitamente a float.
     return [float(F1), float(F2), float(F3), float(F4), float(F5)]
 
 # ==================== DECODIFICACIÓN ====================
@@ -40,37 +47,62 @@ MESSAGE_LENGTH = 13
 SENSOR_TAG_MAP = {ord('A'): "acc", ord('a'): "acc", 1: "acc"}
 
 def decode_serialsensor_binary(pkt: bytes):
+    """Lee un paquete binario de 13 bytes y extrae aceleraciones en formato flotante."""
+    # Verifica que el mensaje tenga exactamente el tamaño esperado.
     if len(pkt) != MESSAGE_LENGTH:
         return None
+    # Recupera el byte de encabezado que identifica el tipo de sensor.
     tag = pkt[0]
+    # Busca el prefijo textual asociado al identificador.
     pref = SENSOR_TAG_MAP.get(tag)
+    # Descarta el paquete si no corresponde a un acelerómetro.
     if pref != "acc":
         return None
     try:
+        # Desempaqueta el valor del eje X usando formato float little-endian.
         x = struct.unpack_from('<f', pkt, 1)[0]
+        # Desempaqueta el eje Y a partir del offset 5.
         y = struct.unpack_from('<f', pkt, 5)[0]
+        # Desempaqueta el eje Z desde el offset 9.
         z = struct.unpack_from('<f', pkt, 9)[0]
+        # Devuelve los tres ejes normalizados como flotantes.
         return ("acc", float(x), float(y), float(z))
     except Exception:
+        # En caso de error de desempaquetado se descarta el paquete.
         return None
 
 def iter_pairs_from_json_msg(msg: dict):
+    """Extrae triples (sensor, eje, valor) de las variantes JSON aceptadas."""
+    # Recorre todos los pares clave/valor del mensaje original.
     for k, v in list(msg.items()):
+        # Solo procesa claves que contengan el separador sensor:eje.
         if isinstance(k, str) and ":" in k:
+            # Divide en prefijo y eje usando la primera aparición de ":".
             s, a = k.split(":", 1)
+            # Normaliza ambos fragmentos a minúsculas sin espacios externos.
             s, a = s.strip().lower(), a.strip().lower()
+            # Comprueba que el prefijo sea de acelerómetro y que el eje sea válido.
             if s in ("accel","accelerometer","acc") and a in ("x","y","z"):
+                # Produce el par normalizado para su consumo en el pipeline.
                 yield "acc", a, v
+    # Examina si existe una sección "sensordata" más estructurada.
     sd = msg.get("sensordata")
+    # Continúa solo si dicha sección es un diccionario.
     if isinstance(sd, dict):
+        # Itera sobre cada sensor descrito dentro del bloque.
         for sensor, payload in sd.items():
+            # Verifica que el nombre del sensor corresponda a un acelerómetro.
             if str(sensor).lower().startswith("acc"):
                 if isinstance(payload, dict):
+                    # Recorre los ejes explícitos del diccionario interno.
                     for axis, val in payload.items():
+                        # Normaliza el nombre del eje para validarlo.
                         a = str(axis).lower()
                         if a in ("x","y","z"):
+                            # Devuelve cada eje acompañado de su valor.
                             yield "acc", a, val
                 elif isinstance(payload, (list, tuple)) and len(payload) >= 3:
+                    # Para secuencias, asigna los primeros tres valores a X, Y, Z respectivamente.
                     for a, val in zip(("x","y","z"), payload[:3]):
                         yield "acc", a, val
 
@@ -96,73 +128,100 @@ except Exception as e:
 
 # ==================== HILO UDP + PREDICCIÓN ====================
 def udp_loop():
+    """Escucha paquetes UDP, mantiene la ventana y actualiza la predicción compartida."""
+    # Crea un socket UDP para recibir lecturas del sensor.
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    # Vincula el socket a la interfaz y puerto configurados.
     sock.bind((UDP_HOST, UDP_PORT))
+    # Define un timeout para evitar bloqueos indefinidos.
     sock.settimeout(1.0)
+    # Informa en consola que el listener está activo.
     print(f"[UDP] Escuchando en {UDP_HOST}:{UDP_PORT}")
 
+    # Registra el instante de la última predicción para respetar STEP_SEC.
     last_pred_t = 0.0
     try:
         while True:
+            # Obtiene el tiempo actual al inicio del ciclo.
             now = time.time()
-            # Purga ventana
+            # Calcula el límite inferior permitido en la ventana deslizante.
             cutoff = now - WINDOW_SEC
             with state_lock:
+                # Elimina muestras antiguas que queden fuera de la ventana.
                 while window and window[0][0] < cutoff:
                     window.popleft()
 
-            # Recibir
             try:
+                # Intenta recibir un datagrama desde el socket.
                 data, _ = sock.recvfrom(65535)
             except socket.timeout:
+                # Si no llegan datos a tiempo, sigue el ciclo.
                 data = None
 
             if data:
+                # Maneja paquetes binarios del tamaño esperado para Serial Sensor.
                 if len(data) == MESSAGE_LENGTH:
                     decoded = decode_serialsensor_binary(data)
                     if decoded:
+                        # Obtiene las componentes XYZ y las incorpora a la ventana.
                         _, x, y, z = decoded
                         with state_lock:
                             window.append((now, x, y, z))
+                # Maneja mensajes JSON cuando el primer byte indica "{" o "[".
                 elif data[:1] in (b'{', b'['):
                     try:
+                        # Decodifica el paquete a texto y luego a objeto Python.
                         msg = json.loads(data.decode("utf-8", errors="ignore"))
                     except Exception:
+                        # Descarta el mensaje si la decodificación falla.
                         msg = None
                     if isinstance(msg, dict):
+                        # Inicializa el diccionario para asegurarse de completar los tres ejes.
                         axes = {"x": None, "y": None, "z": None}
                         for pref, axis, val in iter_pairs_from_json_msg(msg):
                             if pref == "acc":
                                 try:
+                                    # Intenta convertir el valor recibido a float.
                                     axes[axis] = float(val)
                                 except (TypeError, ValueError):
+                                    # Ignora valores no numéricos manteniendo el eje como None.
                                     pass
                         if None not in axes.values():
                             with state_lock:
+                                # Inserta la medición completa en la ventana.
                                 window.append((now, axes["x"], axes["y"], axes["z"]))
 
-            # Predicción periódica
+            # Comprueba si ya transcurrió el paso mínimo para evaluar el modelo.
             if (now - last_pred_t) >= STEP_SEC:
+                # Actualiza el marcador de tiempo de la última predicción.
                 last_pred_t = now
                 with state_lock:
+                    # Calcula el número de muestras disponibles en la ventana.
                     n = len(window)
                     if n >= 3:
+                        # Transforma la ventana a arreglo NumPy con formato consistente.
                         arr = np.array([[t, ax, ay, az] for (t, ax, ay, az) in window], dtype=float)
+                        # Construye un DataFrame con los ejes para reutilizar la ingeniería de características.
                         df_win = pd.DataFrame(arr[:, 1:], columns=["Ax","Ay","Az"])
+                        # Calcula las características derivadas de la ventana actual.
                         F = ingenieriaCaracteristicas(df_win)
 
                         if model is not None:
                             try:
+                                # Obtiene la probabilidad de la clase "R" desde el modelo entrenado.
                                 prob = float(model.predict_proba([F])[0, 1])
+                                # Define la etiqueta en función del umbral 0.5 habitual.
                                 label = "R" if prob >= 0.5 else "L"
                             except Exception as e:
-                                # fallback
+                                # Si el modelo falla en inferencia, recurre al plan de contingencia.
                                 prob = 1.0 / (1.0 + np.exp(-(F[4] - f5_threshold_default)))
                                 label = "R" if F[4] > f5_threshold_default else "L"
                         else:
+                            # Sin modelo cargado, utiliza la sigmoide sobre F5 como aproximación.
                             prob = 1.0 / (1.0 + np.exp(-(F[4] - f5_threshold_default)))
                             label = "R" if F[4] > f5_threshold_default else "L"
 
+                        # Actualiza el estado compartido con la predicción y metadatos auxiliares.
                         last_pred.update({
                             "label": label,
                             "prob_rapido": prob,
@@ -172,8 +231,10 @@ def udp_loop():
                         })
     finally:
         try:
+            # Cierra el socket al salir del bucle principal.
             sock.close()
         except Exception:
+            # Ignora cualquier error al cerrar para no interrumpir el apagado.
             pass
 
 # ==================== APP WEB (Flask) ====================
@@ -309,6 +370,8 @@ HTML = """
 
 @app.route("/")
 def index():
+    """Renderiza la plantilla del dashboard pasando los parámetros de configuración."""
+    # Devuelve la página HTML principal con los datos de contexto necesarios para la UI.
     return render_template(
         "dashboard.html",
         win=WINDOW_SEC,
@@ -321,8 +384,11 @@ def index():
 
 @app.route("/api/status")
 def api_status():
+    """Entrega el último estado de predicción en formato JSON para el frontend."""
+    # Protege el acceso al diccionario compartido con el candado global.
     with state_lock:
         payload = dict(last_pred)
+    # Serializa la información del estado y la retorna como respuesta HTTP.
     return jsonify(payload)
 
 # ==================== ENTRYPOINT ====================


### PR DESCRIPTION
## Summary
- Actualicé el README para describir ambos servidores, detallar la preparación del entorno virtual e indicar las dependencias necesarias.
- Añadí documentación detallada en `servidor_basico.py` explicando cada función y sus operaciones línea por línea.
- Documenté `servidor_web.py` con docstrings y comentarios que aclaran el flujo completo del hilo UDP y la API Flask.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df7d9e40388331aab1884a55f68849