### PR TITLE
Documenta ejecución sin logs con nohup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ Cada script declara constantes de configuración al inicio del archivo:
 4. Accede a `http://HTTP_HOST:HTTP_PORT` para visualizar el tablero. El endpoint
    `/api/status` devuelve el último resultado en JSON, útil para integraciones.
 
+### Ejecutar `servidor_web.py` con `nohup`
+
+Para mantener el servidor web activo después de cerrar la terminal puedes usar `nohup`.
+
+- **Sin registro alguno** (descarta toda la salida estándar y de error):
+
+  ```bash
+  nohup python servidor_web.py > /dev/null 2>&1 &
+  ```
+
+- **Sin archivo de log dedicado** (la salida se almacena en `nohup.out` por defecto):
+
+  ```bash
+  nohup python servidor_web.py &
+  ```
+
+- **Con un archivo de log específico** para revisar la salida estándar y de error:
+
+  ```bash
+  nohup python servidor_web.py > servidor_web.log 2>&1 &
+  ```
+
 ## Formatos de mensaje admitidos
 
 Ambos servidores aceptan:


### PR DESCRIPTION
## Summary
- añade instrucciones para ejecutar `servidor_web.py` con `nohup` descartando toda la salida
- mantiene las variantes existentes para `nohup` con `nohup.out` y con archivo de log dedicado

## Testing
- no tests were run (not needed for docs)


------
https://chatgpt.com/codex/tasks/task_e_68e03d516b50833190b19103d66dc7b0